### PR TITLE
feat(shortcuts): add toggle todos via shortcuts, not sure about api

### DIFF
--- a/src/components/story/story.html
+++ b/src/components/story/story.html
@@ -56,6 +56,8 @@
                     class="todo"
                     dnd-draggable="todoId"
                     dnd-type="['todo',story]">
+                    <span class="pull-left" ng-if="state.tasks.items[todoId].checked">{{bindList[todoId]}} u</span>
+                    <span class="pull-left" ng-if="!state.tasks.items[todoId].checked">{{bindList[todoId]}} c</span>
                     <div
                         task="state.tasks.items[todoId]"
                         edit="state.ui.stories[story.id].edit"

--- a/src/components/story/story.js
+++ b/src/components/story/story.js
@@ -94,6 +94,7 @@ export function StoryController($scope, store, uuid) {
     $scope.$watch('story.todos', () => {
         if ($scope.state.ui.selected_story && $scope.state.ui.selected_story.id == $scope.story.id) {
             $scope.unbindTodos()
+            $scope.bindTodos()
         }
     })
 

--- a/src/shortcuts.js
+++ b/src/shortcuts.js
@@ -9,10 +9,20 @@ const STORY_SIZE_DOWN = "cmd+down"
 const STORY_OPEN = "enter"
 const STORY_CLOSE = "esc"
 
+export function bind(keys, fn, event) {
+    Mousetrap.bind(keys, fn, event)
+
+    return () => {
+        return Mousetrap.unbind(keys)
+    }
+}
+
+
 export function init(app) {
     app.run(function(store) {
+
         // that's free of charge
-        var __ = Mousetrap.bind
+        var __ = bind
 
         function getSelectedStory() {
             return store.getState().ui.selected_story


### PR DESCRIPTION
sequences in the gif:
- enter
- tac
- tau
- tec
- teu
- toc
- tou

![shortcuts](https://cloud.githubusercontent.com/assets/543507/12460540/111459ba-bfac-11e5-8a09-b7fde7560277.gif)

The syntax is "t" as in todo, then one or several letters, then "c" as in check, or "u" as in uncheck

I don't like the way it's done though, too much work for that
